### PR TITLE
change id in example to string

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,31 +53,31 @@ import { TreeView, TreeDataItem } from '@/components/ui/tree-view';
 
 const data: TreeDataItem[] = [
   {
-    id: 1,
+    id: '1',
     name: 'Item 1',
     children: [
       {
-        id: 2,
+        id: '2',
         name: 'Item 1.1',
         children: [
           {
-            id: 3,
+            id: '3',
             name: 'Item 1.1.1',
           },
           {
-            id: 4,
+            id: '4',
             name: 'Item 1.1.2',
           },
         ],
       },
       {
-        id: 5,
+        id: '5',
         name: 'Item 1.2',
       },
     ],
   },
   {
-    id: 6,
+    id: '6',
     name: 'Item 2',
   },
 ];


### PR DESCRIPTION
TreeDataItem.id is a string, but example code was setting to a number.

```js
interface TreeDataItem {
    id: string
```