### PR TITLE
only rotate first svg (not icon)

### DIFF
--- a/src/tree-view.tsx
+++ b/src/tree-view.tsx
@@ -413,7 +413,7 @@ const AccordionTrigger = React.forwardRef<
         <AccordionPrimitive.Trigger
             ref={ref}
             className={cn(
-                'flex flex-1 w-full items-center py-2 transition-all first:[&[data-state=open]>svg]:rotate-90',
+                'flex flex-1 w-full items-center py-2 transition-all first:[&[data-state=open]>svg]:first-of-type:rotate-90',
                 className
             )}
             {...props}


### PR DESCRIPTION
When adding svg icons, they are rotated along with the chevron.