### PR TITLE
fix: rotate only chevron, not custom icons

### DIFF
--- a/src/tree-view.tsx
+++ b/src/tree-view.tsx
@@ -413,7 +413,7 @@ const AccordionTrigger = React.forwardRef<
         <AccordionPrimitive.Trigger
             ref={ref}
             className={cn(
-                'flex flex-1 w-full items-center py-2 transition-all first:[&[data-state=open]>svg]:rotate-90',
+                'flex flex-1 w-full items-center py-2 transition-all [&[data-state=open]>svg:first-of-type]:rotate-90',
                 className
             )}
             {...props}


### PR DESCRIPTION

https://github.com/user-attachments/assets/0853c007-bd71-4570-a3a5-f825ddac9e60

I had to add this fix in my code to prevent the custom icon to be rotated when opening items. 

Thanks for this tree view component! 😃 