### PR TITLE
feat: support custom className for tree items

### DIFF
--- a/src/tree-view.tsx
+++ b/src/tree-view.tsx
@@ -30,6 +30,7 @@ interface TreeDataItem {
     draggable?: boolean
     droppable?: boolean
     disabled?: boolean
+    className?: string
 }
 
 type TreeProps = React.HTMLAttributes<HTMLDivElement> & {
@@ -60,7 +61,7 @@ const TreeView = React.forwardRef<HTMLDivElement, TreeProps>(
         const [selectedItemId, setSelectedItemId] = React.useState<
             string | undefined
         >(initialSelectedItemId)
-        
+
         const [draggedItem, setDraggedItem] = React.useState<TreeDataItem | null>(null)
 
         const handleSelectChange = React.useCallback(
@@ -131,8 +132,7 @@ const TreeView = React.forwardRef<HTMLDivElement, TreeProps>(
                 />
                 <div
                     className='w-full h-[48px]'
-                    onDrop={(e) => { handleDrop({id: '', name: 'parent_div'})}}>
-
+                    onDrop={() => { handleDrop({id: '', name: 'parent_div'})}}>
                 </div>
             </div>
         )
@@ -271,7 +271,8 @@ const TreeNode = ({
                     className={cn(
                         treeVariants(),
                         selectedItemId === item.id && selectedTreeVariants(),
-                        isDragOver && dragOverVariants()
+                        isDragOver && dragOverVariants(),
+                        item.className
                     )}
                     onClick={() => {
                         handleSelectChange(item)
@@ -376,7 +377,8 @@ const TreeLeaf = React.forwardRef<
                     className,
                     selectedItemId === item.id && selectedTreeVariants(),
                     isDragOver && dragOverVariants(),
-                    item.disabled && 'opacity-50 cursor-not-allowed pointer-events-none'
+                    item.disabled && 'opacity-50 cursor-not-allowed pointer-events-none',
+                    item.className
                 )}
                 onClick={() => {
                     if (item.disabled) return


### PR DESCRIPTION
Hello, thanks for this TreeView component. Here's a small PR to make each item's styling a bit more customizable.

## What changed
- Added `className` prop to `TreeDataItem` interface
- Tree items can now have custom CSS classes
- Applied `item.className` to both TreeNode and TreeLeaf components

## Why
Allows users to customize styling of individual tree items. For example:
- Add specific styling for active items
- Highlight important nodes
- Apply custom themes per item
